### PR TITLE
Password length checked for less than 7 char

### DIFF
--- a/src/checker/PasswordControl.java
+++ b/src/checker/PasswordControl.java
@@ -19,7 +19,7 @@ public class PasswordControl
         String res = "";
 
         //Size above 7:
-        if( passIn.length()<7 ){
+        if (passIn.length() <= 7) {
             res = "Too short";
         }
         


### PR DESCRIPTION
The text and comment says the password should not be less than 8 char, but
it checked for less than 7 char
